### PR TITLE
Device settings msg

### DIFF
--- a/lib/fitreader/sdk/enums.yml
+++ b/lib/fitreader/sdk/enums.yml
@@ -664,3 +664,56 @@
 :enum_length_type:
   0: :idle
   1: :active
+
+:enum_time_mode:
+  0: :hour12
+  1: :hour24
+  2: :military
+  3: :hour_12_with_seconds
+  4: :hour_24_with_seconds
+  5: :utc
+
+:enum_backlight_mode:
+  0: :off
+  1: :manual
+  2: :kay_and_messages
+  3: :auto_brightness
+  4: :smart_notifications
+  5: :key_and_messages_night
+  6: :key_and_messages_and_smart_notifications
+
+:enum_date_mode:
+  0: :day_month
+  1: :month_day
+
+:enum_display_orientation:
+  0: :auto
+  1: :portrait
+  2: :landscape
+  3: :portrait_flipped
+  4: :landscape_flipped
+
+:enum_side:
+  0: :right
+  1: :left
+
+:enum_auto_sync_frequency:
+  0: :never
+  1: :occasionally
+  2: :frequent
+  3: :once_a_day
+  4: :remote
+
+:enum_auto_activity_detect:
+  0: :none
+  1: :running
+  2: :cycling
+  4: :swimming
+  8: :walking
+  32: :elliptical
+  1024: :sedentary
+
+:enum_switch:
+  0: :off
+  1: :on
+  2: :auto

--- a/lib/fitreader/sdk/enums.yml
+++ b/lib/fitreader/sdk/enums.yml
@@ -652,6 +652,15 @@
   123: :bike_speed
   124: :stride_speed_distance
 
+:enum_swim_stroke:
+  0: :freestyle
+  1: :backstroke
+  2: :breastroke
+  3: :butterfly
+  4: :drill
+  5: :mixed
+  6: :im
+
 :enum_length_type:
   0: :idle
   1: :active

--- a/lib/fitreader/sdk/fields.yml
+++ b/lib/fitreader/sdk/fields.yml
@@ -2035,7 +2035,7 @@
   7:
     :name: :swim_stroke
     :type: :enum_swim_stroke
-    :scale: 1000
+    :scale: 0
     :offset: 0
   9:
     :name: :avg_swimming_cadence

--- a/lib/fitreader/sdk/fields.yml
+++ b/lib/fitreader/sdk/fields.yml
@@ -34,6 +34,118 @@
     :type: :raw
     :scale: 0
     :offset: 0
+2:
+  0:
+    :name: :activity_time_zone
+    :type: :unit8
+    :scale: 0
+    :offset: 0
+  1:
+    :name: :utc_offset
+    :type: :unit32
+    :scale: 0
+    :offset: 0
+  2:
+    :name: :time_offset
+    :type: :unit32
+    :scale: 0
+    :offset: 0
+  4:
+    :name: :time_mode
+    :type: :enum_time_mode
+    :scale: 0
+    :offset: 0
+  5:
+    :name: :time_zone_offset
+    :type: :sint8
+    :scale: 4
+    :offset: 0
+  36:
+    :name: :backlight_mode
+    :type: :enum_backlight_mode
+    :scale: 0
+    :offset: 0
+  39:
+    :name: :clock_time
+    :type: :date_time
+    :scale: 0
+    :offset: 0
+  40:
+    :name: :pages_enabled
+    :type: :uint16
+    :scale: 0
+    :offset: 0
+  46:
+    :name: :move_alert_enabled
+    :type: :bool
+    :scale: 0
+    :offset: 0
+  47:
+    :name: :date_mode
+    :type: :enum_date_mode
+    :scale: 0
+    :offset: 0
+  55:
+    :name: :display_orientation
+    :type: :enum_display_orientation
+    :scale: 0
+    :offset: 0
+  56:
+    :name: :mounting_side
+    :type: :enum_side
+    :scale: 0
+    :offset: 0
+  57:
+    :name: :default_page
+    :type: :uint16
+    :scale: 0
+    :offset: 0
+  58:
+    :name: :autosync_min_steps
+    :type: :uint16
+    :scale: 0
+    :offset: 0
+  59:
+    :name: :auto_sync_min_time
+    :type: :uint16
+    :scale: 0
+    :offset: 0
+  80:
+    :name: :lactate_threshold_autodetect_enabled
+    :type: :bool
+    :scale: 0
+    :offset: 0
+  86:
+    :name: :ble_auto_upload_enabled
+    :type: :bool
+    :scale: 0
+    :offset: 0
+  89:
+    :name: :auto_sync_frequency
+    :type: :enum_auto_sync_frequency
+    :scale: 0
+    :offset: 0
+  90:
+    :name: :auto_activity_detect
+    :type: :uint32   #:enum_auto_activity_detect
+    :scale: 0
+    :offset: 0
+  94:
+    :name: :number_of_screens
+    :type: :uint8
+    :scale: 0
+    :offset: 0
+  95:
+    :name: :smart_notification_display_orientation
+    :type: :enum_display_orientation
+    :scale: 0
+    :offset: 0
+  134:
+    :name: :tap_interface
+    :type: :enum_switch
+    :scale: 0
+    :offset: 0
+
 3:
   254:
     :name: :message_index


### PR DESCRIPTION
@richardbrodie Been taking a look at options for #3 and think maybe I found a solution. It doesn't really affect me anymore as I'm using our client's timezone to calculate the local timezone from the :start_time field however I noticed that :device_settings message type has the :time_offset field and other fields which might be useful for this so I added the device settings message type in case you think it will work for that issue