### PR TITLE
Fix typo: Should be val= (not just val)

### DIFF
--- a/lib/fitreader/message.rb
+++ b/lib/fitreader/message.rb
@@ -33,7 +33,7 @@ class Message
       val = Sdk.enum(type[:type])[val]
     elsif type[:type] == :date_time
       t = Time.new(1989, 12, 31, 0, 0, 0, '+00:00').utc.to_i
-      val Time.at(val + t).utc
+      val = Time.at(val + t).utc
     elsif type[:type] == :local_date_time
       t = Time.new(1989, 12, 31, 0, 0, 0, '+02:00').utc.to_i
       val = Time.at(val + t)


### PR DESCRIPTION


executing
```
fit_file = Fit.new(File.new('12203707685_ACTIVITY.fit'))
```
throws
```
undefined method `val' for #<Message:0x000000013b401af0>
Did you mean?  eval
/Users/tomcollins/Documents/workspace/fitreader/lib/fitreader/message.rb:19: warning: wrong element type nil at 0 (expected array)
/Users/tomcollins/Documents/workspace/fitreader/lib/fitreader/message.rb:19: warning: ignoring wrong elements is deprecated, remove them explicitly
/Users/tomcollins/Documents/workspace/fitreader/lib/fitreader/message.rb:19: warning: this causes ArgumentError in the next release
```
error due to a typo.